### PR TITLE
Fix runtime error caused by reflection warnings

### DIFF
--- a/src/xmas/core.clj
+++ b/src/xmas/core.clj
@@ -30,4 +30,5 @@
 
 (defn -main [& [size]]
   (let [size (or (and size (Long/parseLong size)) default-size)]
-    (write-tree *out* size)))
+    (write-tree *out* size)
+    (flush)))

--- a/src/xmas/core.clj
+++ b/src/xmas/core.clj
@@ -1,5 +1,6 @@
 (ns xmas.core
-  (:gen-class))
+  (:gen-class)
+  (:import [java.io Writer]))
 
 (defn color [code s] (str \u001b "[" code "m" s \u001b "[m"))
 (defn strs  [n s] (apply str (repeat n s)))
@@ -16,8 +17,8 @@
               \u0020 \u2E1B \u2042 \u2E2E "&" "@" \uFF61])
 (def object-colors [21 33 34 35 36 37])
 
-(defn write-tree [writer size]
-  (letfn [(write [s] (.write writer s))]
+(defn write-tree [^Writer writer size]
+  (letfn [(write [^String s] (.write writer s))]
     (write (str (strs (inc size) " ") star "\n"))
     (doseq [l (map inc (range size))]
       (write (str (strs (- size l) " ") left))


### PR DESCRIPTION
On my environment, I've run into a runtime error when running the program, such like:

```
Exception in thread "main" java.lang.IllegalArgumentException: No matching method found: write for class java.io.OutputStreamWriter
        at java.lang.Throwable.<init>(Throwable.java:265)                                 
        at java.lang.Exception.<init>(Exception.java:66)                                  
        at java.lang.RuntimeException.<init>(RuntimeException.java:62)
        at java.lang.IllegalArgumentException.<init>(IllegalArgumentException.java:52)                                                                                                                                                                                                            
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:53)                                                                                                                                                                                                                         
        at clojure.lang.Reflector.invokeInstanceMethod(Reflector.java:28)                                                                                                                                                                                                                         
        at xmas.core$write_tree$write__880.invoke(core.clj:20)                                                                                                                                                                                                                                    
        at xmas.core$write_tree.invokeStatic(core.clj:21)                     
        at xmas.core$write_tree.invoke(core.clj:19)                                                                                                                                                                                                                                               
        at xmas.core$_main.invokeStatic(core.clj:32)           
        at xmas.core$_main.doInvoke(core.clj:30)
        at clojure.lang.RestFn.invoke(RestFn.java:397)                                                                                                                                                                                                                                            
        at clojure.lang.AFn.applyToHelper(AFn.java:152)                                                                                                                                                                                                                                                    at clojure.lang.RestFn.applyTo(RestFn.java:132)                                                                                                                                                                                                                                           
        at xmas.core.main(Unknown Source)                                                 
        at com.oracle.svm.core.JavaMainWrapper.run(JavaMainWrapper.java:164)  
```

It looks like the error was caused by reflection warnings according to the error message. 
This PR fixes the issue, and also flushes the whole output after rendering the tree to ensure its appearance.